### PR TITLE
Oracle compatible query

### DIFF
--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -153,7 +153,7 @@ module ActsAsNestedInterval
     end
 
     def ancestors
-      sqls = ["NULL"]
+      sqls = []
       p, q = lftp, lftq
       while p != 0
         x = p.inverse(q)


### PR DESCRIPTION
`sqls['NULL']` caused fatal error when querying with Oracle (using oracle_enhanced). I removed it and everything works fine now.
