### PR TITLE
Fix problem with activerecord-oracle_enhanced-adapter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_nested_interval (0.0.4)
+    acts_as_nested_interval (0.0.7)
       rails (~> 3.2.1)
 
 GEM
@@ -48,7 +48,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.18)
+    mime-types (1.19)
     multi_json (1.1.0)
     polyglot (0.3.3)
     rack (1.4.1)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Nested sets/intervals are good if you need to sort in preorder at DB-level.
 If you don't need that give a look to https://github.com/stefankroes/ancestry ,
 that implements a simpler encoding model (variant of materialized path).  
 
+The original version of this gem is at https://github.com/clyfe/acts_as_nested_interval of Nicolae Claudius.
+
+## Modification
+ 
+The modification includes:
+  - Remove specific syntax of Ruby 1.9 and make it work in JRuby and Ruby 1.8.x.
+  - Add the options :children_dependent so that we can optionally select the dependency between the parent node and its children nodes.
 
 ## Install
 
@@ -93,6 +100,29 @@ australia.parent       # => oceania
 new_zealand.ancestors  # => [earth, oceania]
 Region.roots           # => [earth]
 ```
+
+More options:
+
+```ruby
+class Country < ActiveRecord::Base
+  has_many :regions, :dependent => :destroy
+end
+
+class Region < ActiveRecord::Base 
+  acts_as_nested_interval(
+    # An array of columns to scope independent trees.
+    :scope_columns => [:country_id],
+    
+    # This option will not create a root node, but use a 'virtual root' instead.
+    :virtual_root => true,
+    
+    # Dependency between the parent node and children nodes (default :restrict).
+    :children_dependent => :destroy
+  )
+end
+```
+
+Please note that the options `:scope_columns` should always goes along with `:virtual_root => true` to make sure each scope (e.g `Country`) will have a separated root node. Otherwise, we will get some unexpected error because the root node was shared among trees.
 
 ## How it works
 

--- a/lib/acts_as_nested_interval.rb
+++ b/lib/acts_as_nested_interval.rb
@@ -19,10 +19,12 @@ module ActsAsNestedInterval
   # * <tt>:scope_columns</tt> -- an array of columns to scope independent trees.
   # * <tt>:lft_index</tt> -- whether to use functional index for lft (default false).
   # * <tt>:virtual_root</tt> -- whether to compute root's interval as in an upper root (default false)
+  # * <tt>:children_dependent</tt> -- dependency between the parent node and children nodes (default :restrict)
   def acts_as_nested_interval(options = {})
     cattr_accessor :nested_interval_foreign_key
     cattr_accessor :nested_interval_scope_columns
     cattr_accessor :nested_interval_lft_index
+    cattr_accessor :nested_interval_children_dependent
       
     cattr_accessor :virtual_root
     self.virtual_root = !!options[:virtual_root]
@@ -30,9 +32,11 @@ module ActsAsNestedInterval
     self.nested_interval_foreign_key = options[:foreign_key] || :parent_id
     self.nested_interval_scope_columns = Array(options[:scope_columns])
     self.nested_interval_lft_index = options[:lft_index]
+    self.nested_interval_children_dependent = options[:children_dependent] || :restrict
       
-    belongs_to :parent, class_name: name, foreign_key: nested_interval_foreign_key
-    has_many :children, class_name: name, foreign_key: nested_interval_foreign_key, dependent: :restrict
+    belongs_to :parent, :class_name => name, :foreign_key => nested_interval_foreign_key
+    has_many :children, :class_name => name, :foreign_key => nested_interval_foreign_key, 
+                        :dependent => nested_interval_children_dependent
     scope :roots, where(nested_interval_foreign_key => nil)
       
     if columns_hash["rgt"]

--- a/lib/acts_as_nested_interval/class_methods.rb
+++ b/lib/acts_as_nested_interval/class_methods.rb
@@ -18,11 +18,11 @@ module ActsAsNestedInterval
           
       # recompute intervals with a recursive lambda
       clear_cache!
-      update_subtree = lambda(node){
+      update_subtree = lambda do |node| 
         node.create_nested_interval
         node.save
         node.class.unscoped.where(nested_interval_foreign_key => node.id).find_each &update_subtree
-      }
+      end
       unscoped.roots.find_each &update_subtree
 
       # revert changes

--- a/lib/acts_as_nested_interval/class_methods.rb
+++ b/lib/acts_as_nested_interval/class_methods.rb
@@ -9,7 +9,7 @@ module ActsAsNestedInterval
       default_scope where("#{quoted_table_name}.lftq > 0") # use lft1 > 0 as a "migrated?" flag
           
       # zero all intervals
-      update_hash = {lftp: 0, lftq: 0}
+      update_hash = {:lftp => 0, :lftq => 0}
       update_hash[:rgtp] = 0 if columns_hash["rgtp"]
       update_hash[:rgtq] = 0 if columns_hash["rgtq"]
       update_hash[:lft]  = 0 if columns_hash["lft"]
@@ -18,7 +18,7 @@ module ActsAsNestedInterval
           
       # recompute intervals with a recursive lambda
       clear_cache!
-      update_subtree = ->(node){
+      update_subtree = lambda(node){
         node.create_nested_interval
         node.save
         node.class.unscoped.where(nested_interval_foreign_key => node.id).find_each &update_subtree

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -166,7 +166,11 @@ module ActsAsNestedInterval
         p, q = (x * p - 1) / q, x
         sqls << "lftq = #{q} AND lftp = #{p}"
       end
-      nested_interval_scope.where(sqls * ' OR ')
+      unless sqls.blank?
+        nested_interval_scope.where(sqls * ' OR ')
+      else
+        nested_interval_scope.limit(0)
+      end
     end
 
     # Returns depth by counting ancestors up to 0 / 1.

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -153,7 +153,7 @@ module ActsAsNestedInterval
     end
 
     def ancestors
-      sqls = ["NULL"]
+      sqls = []
       p, q = lftp, lftq
       while p != 0
         x = p.inverse(q)


### PR DESCRIPTION
Here is my new method 'ancestors' in lib/acts_as_nested_interval/instance_methods.rb:

``` ruby
    def ancestors
      sqls = []
      p, q = lftp, lftq
      while p != 0
        x = p.inverse(q)
        p, q = (x * p - 1) / q, x
        sqls << "lftq = #{q} AND lftp = #{p}"
      end
      unless sqls.blank?
        nested_interval_scope.where(sqls * ' OR ')
      else
        nested_interval_scope.limit(0)
      end
    end
```

All test cases are passed.
