### PR TITLE
Moving node breaks in some scenarios

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_nested_interval (0.0.7)
+    acts_as_nested_interval (0.0.8)
       rails (~> 3.2.1)
 
 GEM
@@ -50,6 +50,8 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.19)
     multi_json (1.1.0)
+    mysql2 (0.3.11)
+    pg (0.14.1)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.1)
@@ -94,4 +96,6 @@ PLATFORMS
 DEPENDENCIES
   acts_as_nested_interval!
   jquery-rails
+  mysql2
+  pg
   sqlite3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_nested_interval (0.0.8)
+    acts_as_nested_interval (0.0.7)
       rails (~> 3.2.1)
 
 GEM
@@ -50,8 +50,6 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.19)
     multi_json (1.1.0)
-    mysql2 (0.3.11)
-    pg (0.14.1)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.1)
@@ -96,6 +94,4 @@ PLATFORMS
 DEPENDENCIES
   acts_as_nested_interval!
   jquery-rails
-  mysql2
-  pg
   sqlite3

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -145,10 +145,11 @@ module ActsAsNestedInterval
       
       db_descendants.update_all %(
         lftp = #{cpp} * lftp + #{cpq} * lftq,
-        lftq = #{cqp} * #{mysql_tmp}lftp + #{cqq} * lftq
+        lftq = #{cqp} * #{mysql_tmp}lftp + #{cqq} * lftq,
+        lft = 1.0 * lftp / lftq
       ), mysql_tmp && %(@lftp := lftp)
       
-      db_descendants.update_all %(lft = 1.0 * lftp / lftq) if has_attribute?(:lft)
+      #db_descendants.update_all %(lft = 1.0 * lftp / lftq) if has_attribute?(:lft)
     end
     
     def ancestor_of?(node)

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -127,31 +127,36 @@ module ActsAsNestedInterval
       else # child move
         set_nested_interval *parent.next_child_lft
       end
-      mysql_tmp = "@" if ["MySQL", "Mysql2"].include?(connection.adapter_name)
+      @mysql_tmp = "@" if ["MySQL", "Mysql2"].include?(connection.adapter_name)
       cpp = db_self.lftq * rgtp - db_self.rgtq * lftp
       cpq = db_self.rgtp * lftp - db_self.lftp * rgtp
       cqp = db_self.lftq * rgtq - db_self.rgtq * lftq
       cqq = db_self.rgtp * lftq - db_self.lftp * rgtq
       
-      db_descendants = db_self.descendants
-      
+      updates = {}
+      variables =[:lftp, :lftq]
+
       if has_attribute?(:rgtp) && has_attribute?(:rgtq)
-        db_descendants.update_all %(
-          rgtp = #{cpp} * rgtp + #{cpq} * rgtq,
-          rgtq = #{cqp} * #{mysql_tmp}rgtp + #{cqq} * rgtq
-        ), mysql_tmp && %(@rgtp := rgtp)
-        db_descendants.update_all "rgt = 1.0 * rgtp / rgtq" if has_attribute?(:rgt)
+          updates[:rgtp] = newval(cpp, cpq, :rgt)
+          updates[:rgtq] = newval(cqp, cqq, :rgt)
+          variables += [:rgtp, :rgtq]
+          updates[:rgt] = "1.0 * (#{updates[:rgtp]}) / (#{updates[:rgtq]})" if has_attribute?(:rgt)
       end
-      
-      db_descendants.update_all %(
-        lftp = #{cpp} * lftp + #{cpq} * lftq,
-        lftq = #{cqp} * #{mysql_tmp}lftp + #{cqq} * lftq,
-        lft = 1.0 * lftp / lftq
-      ), mysql_tmp && %(@lftp := lftp)
-      
-      #db_descendants.update_all %(lft = 1.0 * lftp / lftq) if has_attribute?(:lft)
+
+      updates[:lftp] = newval(cpp, cpq, :lft)
+      updates[:lftq] = newval(cqp, cqq, :lft)
+      updates[:lft] = "1.0 * (#{updates[:lftp]}) / (#{updates[:lftq]})" if has_attribute?(:lft)
+
+      db_self.descendants.update_all  updates.map{|key, value| "#{key} = #{value}"}.join(', '),
+        @mysql_tmp && variables.map{|name| "(@#{name} := #{name})"}.join(' AND ')
     end
-    
+
+    private
+    def newval p, q, side
+      "#{p} * #{@mysql_tmp}#{side}p + #{q} * #{@mysql_tmp}#{side}q"
+    end
+
+    public
     def ancestor_of?(node)
       node.lftp == lftp && node.lftq == lftq ||
         node.lftp > node.lftq * lftp / lftq &&

--- a/test/acts_as_nested_interval_test.rb
+++ b/test/acts_as_nested_interval_test.rb
@@ -188,7 +188,7 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     assert r3.rgt <= r2.lft
     assert r2.rgt <= r1.lft
   end
-
+  
   def test_virtual_root_allocation
     Region.virtual_root = true
     r1 = Region.create name: "Europe"
@@ -196,10 +196,10 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     r3 = Region.create name: "Asia"
     r4 = Region.create name: "America"
     assert_equal [["Europe", 1.0/2, 1.0], ["Romania", 2.0/3, 1.0],
-                  ["Asia", 1.0/3, 1.0/2], ["America", 1.0/4, 1.0/3]],
-                 Region.preorder.map { |r| [r.name, r.lft, r.rgt] }
+      ["Asia", 1.0/3, 1.0/2], ["America", 1.0/4, 1.0/3]],
+      Region.preorder.map { |r| [r.name, r.lft, r.rgt] }
   end
-
+  
   def test_rebuild_nested_interval_tree
     Region.virtual_root = true
     r1 = Region.create name: "Europe"
@@ -208,10 +208,10 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     r4 = Region.create name: "America"
     Region.rebuild_nested_interval_tree!
     assert_equal [["Europe", 0.5, 1.0], ["Romania", 2.0/3, 1.0],
-                  ["Asia", 1.0/3, 1.0/2], ["America", 1.0/4, 1.0/3]],
-                 Region.preorder.map { |r| [r.name, r.lft, r.rgt] }
+      ["Asia", 1.0/3, 1.0/2], ["America", 1.0/4, 1.0/3]],
+      Region.preorder.map { |r| [r.name, r.lft, r.rgt] }
   end
-
+  
   def test_root_update_keeps_interval
     Region.virtual_root = true
     r1 = Region.create name: "Europe"
@@ -223,7 +223,7 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     r4.save
     assert_equal lftq, r4.lftq
   end
-
+  
   def test_move_to_root_recomputes_interval
     Region.virtual_root = true
     r1 = Region.create name: "Europe"
@@ -235,5 +235,5 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     r2.save
     assert_not_equal lftq, r2.lftq
   end
-
+  
 end

--- a/test/acts_as_nested_interval_test.rb
+++ b/test/acts_as_nested_interval_test.rb
@@ -136,7 +136,7 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     assert_equal 1.0 * 3 / 7, new_zealand.rgt
   end
 
-  def test_move_complex
+  def test_move_from_left_to_right
     root = Region.create name: 'root'
     r1=Region.create(name: 'r1', parent: root)
     l1=Region.create(name: 'l1', parent: root)
@@ -145,44 +145,12 @@ class ActsAsNestedIntervalTest < ActiveSupport::TestCase
     l4=Region.create(name: 'l4', parent: l3)
     l3.parent = r1
     l3.save!
-    l4.reload
     assert_equal 0, l4.reload.descendants.count
     assert_equal 1, l3.reload.descendants.count
-  end
-
-  def test_move_complex2
-    root = Region.create name: 'root'
-    r1=Region.create(name: 'r1', parent: root)
-    r2=Region.create(name: 'r2', parent: r1)
-    r3=Region.create(name: 'r3', parent: r2)
-    r4=Region.create(name: 'r4', parent: r3)
-    l1=Region.create(name: 'l1', parent: root)
-    r1.parent = l1
-    r1.save!
-    assert_equal 0, r4.reload.descendants.count
-    assert_equal 1, r3.reload.descendants.count
-    assert_equal 2, r2.reload.descendants.count
-    assert_equal 3, r1.reload.descendants.count
-    assert_equal 4, l1.reload.descendants.count
+    assert_equal 2, r1.reload.descendants.count
+    assert_equal 1, l1.reload.descendants.count
+    assert_equal 0, l2.reload.descendants.count
     assert_equal 5, root.reload.descendants.count
-  end
-
-
-  def test_move_complex3
-    root = Region.create name: 'root'
-    children = (0..4).map {|i| Region.create name: "c#{i}", parent: root}
-    r1=Region.create(name: 'r1', parent: children.last)
-    r2=Region.create(name: 'r2', parent: r1)
-    r3=Region.create(name: 'r3', parent: r2)
-    r4=Region.create(name: 'r4', parent: r3)
-    l1=Region.create(name: 'l1', parent: children.last)
-    r1.parent = l1
-    r1.save!
-    assert_equal 0, r4.reload.descendants.count
-    assert_equal 1, r3.reload.descendants.count
-    assert_equal 2, r2.reload.descendants.count
-    assert_equal 3, r1.reload.descendants.count
-    assert_equal 4, l1.reload.descendants.count
   end
 
   def test_destroy


### PR DESCRIPTION
Have a look at the test I added. instance_method.rb:151 misses some descendants because the where condition is not true anymore after lftp and lftq have been updated.
All the update_all in this method can be combined to just one update. The query building is just quite complex to make it work for all 3 databases.
This quite serious bug have cost us sleepless night and some data corruption at high profile clients. I would really appreciate if you could have a look to double check I didn't miss anything.
Thank you
Heinrich
