### PR TITLE
Fix problem with migration on empty database

### DIFF
--- a/acts_as_nested_interval.gemspec
+++ b/acts_as_nested_interval.gemspec
@@ -7,9 +7,9 @@ require "acts_as_nested_interval/version"
 Gem::Specification.new do |s|
   s.name        = "acts_as_nested_interval"
   s.version     = ActsAsNestedInterval::VERSION
-  s.authors     = ["Nicolae Claudius", "Pythonic"]
-  s.email       = ["nicolae_claudius@yahoo.com"]
-  s.homepage    = "https://github.com/clyfe/acts_as_nested_interval"
+  s.authors     = ["Nicolae Claudius", "Pythonic", "Grzegorz Łuszczek"]
+  s.email       = ["grzegorz@piklus.pl"]
+  s.homepage    = "https://github.com/grzlus/acts_as_nested_interval"
   s.summary     = "Encode Trees in RDBMS using nested interval method."
   s.description = "Encode Trees in RDBMS using nested interval method for powerful querying and speedy inserts."
 

--- a/lib/acts_as_nested_interval.rb
+++ b/lib/acts_as_nested_interval.rb
@@ -39,20 +39,22 @@ module ActsAsNestedInterval
       dependent: nested_interval_dependent
     scope :roots, -> { where(nested_interval_foreign_key => nil) }
       
-    if columns_hash["rgt"]
-      scope :preorder, -> { order('rgt DESC, lftp ASC') }
-    elsif columns_hash["rgtp"] && columns_hash["rgtq"]
-      scope :preorder, -> { order('1.0 * rgtp / rgtq DESC, lftp ASC') }
-    else
-      scope :preorder, -> { order('nested_interval_rgt(lftp, lftq) DESC, lftp ASC') }
-    end
+    if self.table_exists? # Fix problem with migrating without table
+      if columns_hash["rgt"]
+        scope :preorder, -> { order('rgt DESC, lftp ASC') }
+      elsif columns_hash["rgtp"] && columns_hash["rgtq"]
+        scope :preorder, -> { order('1.0 * rgtp / rgtq DESC, lftp ASC') }
+      else
+        scope :preorder, -> { order('nested_interval_rgt(lftp, lftq) DESC, lftp ASC') }
+      end
 
-    before_create :create_nested_interval
-    before_destroy :destroy_nested_interval
-    before_update :update_nested_interval
-      
-    include ActsAsNestedInterval::InstanceMethods
-    extend ActsAsNestedInterval::ClassMethods
+      before_create :create_nested_interval
+      before_destroy :destroy_nested_interval
+      before_update :update_nested_interval
+        
+      include ActsAsNestedInterval::InstanceMethods
+      extend ActsAsNestedInterval::ClassMethods
+    end
   end
 
 end

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -111,7 +111,9 @@ module ActsAsNestedInterval
       end
     end
     
+    # Rewrite method
     def update_nested_interval_move
+      return if self.class.readonly_attributes.include?(nested_interval_foreign_key.to_sym) # Fix issue #9
       begin
         db_self = self.class.find(id)
         db_parent = self.class.find(read_attribute(nested_interval_foreign_key))

--- a/lib/acts_as_nested_interval/instance_methods.rb
+++ b/lib/acts_as_nested_interval/instance_methods.rb
@@ -176,14 +176,22 @@ module ActsAsNestedInterval
 
     # Returns depth by counting ancestors up to 0 / 1.
     def depth
-      n = 0
-      p, q = lftp, lftq
-      while p != 0
-        x = p.inverse(q)
-        p, q = (x * p - 1) / q, x
-        n += 1
+      if new_record?
+        if parent_id.nil?
+          return 0
+        else
+          return parent.depth + 1
+        end
+      else
+        n = 0
+        p, q = lftp, lftq
+        while p != 0
+          x = p.inverse(q)
+          p, q = (x * p - 1) / q, x
+          n += 1
+        end
+        return n
       end
-      n
     end
 
     def lft; 1.0 * lftp / lftq end

--- a/lib/acts_as_nested_interval/version.rb
+++ b/lib/acts_as_nested_interval/version.rb
@@ -1,3 +1,3 @@
 module ActsAsNestedInterval
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
When we run migration on empty database it  probably fail with error something like that:

```
rake aborted!
PG::Error: BŁĄD:  relation "categories" doesn't exists
LINE 5:                WHERE a.attrelid = '"categories"'::regclass
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"categories"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```

I fix it by checking if main table is exists.
